### PR TITLE
Incorporate additional feedback from community

### DIFF
--- a/projects/ability-to-mute-other-users/README.md
+++ b/projects/ability-to-mute-other-users/README.md
@@ -1,19 +1,18 @@
 ## Mute other users
 
-Users who receive unwanted messages currently have to report the message writer and wait for an administrator to take action. The OpenStreetMap website should make it possible for anyone to painlessly mute (ignore) private messages (but not comments on changesets) from another user.
+Users who receive unwanted messages to their [openstreetmap.org message inbox](https://www.openstreetmap.org/messages/inbox) currently have to report the message writer and wait for an administrator to take action. The OpenStreetMap website should make it possible for anyone to painlessly mute (ignore) private messages (but not comments on changesets) from another user.
 
 * Project: [openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website)
-* Related issues:
+* Related:
   - https://github.com/openstreetmap/openstreetmap-website/issues/3129
-  - https://github.com/openstreetmap/openstreetmap-website/issues/3129#issuecomment-801239631
-  - https://lists.openstreetmap.org/pipermail/dev/2018-September/030383.html
+  - https://community.openstreetmap.org/t/rfc-on-engineering-working-group-project/1542
 
-The expected deliverable is a mergeable pull request towards https://github.com/openstreetmap/openstreetmap-website. It must at least
-- have a list per user of the other muted users based on their user ids in the database
-- must not show in the inbox of a user any message from a user whose user id is on the blacklist
-- must also not show any notifications to a user from a user whose user id is on the blacklist
-- comprise a UI such that a user can see and change which users they have muted (by user id and current user name)
-- declare the business logic how past and future messages are handled in both the Inbox UI and the data model in cases of muting and unmuting
-- cover the intended functionality and all control flow paths by tests
+The expected deliverable is a mergeable pull request towards https://github.com/openstreetmap/openstreetmap-website. It must at least:
+- not display messages sent from user A in user B's inbox if user B has muted user A (this includes messages sent by responding to email notifications)
+- not show any notifications to a user from muted user, including email notifications sent alongside messages
+- comprise a UI such that a user can view and change which users they have muted
+- not allow admins and moderators to be muted
+- declare the business logic how past and future messages are handled in both the Inbox UI and the data model in case of muting and unmuting
+- include a wireframe of all proposed UI changes
+- conform to the CONTRIBUTING.md doc [here](https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md)
 
-The "report" mechanism mentioned in the Github issue is out of scope in this tender.


### PR DESCRIPTION
Incorporates feedback on project description for muting other users from the following places:
* https://community.openstreetmap.org/t/rfc-on-engineering-working-group-project/1542
* https://github.com/openstreetmap/openstreetmap-website/issues/3129