### PR TITLE
Ability to mute users maintainer feedback

### DIFF
--- a/projects/ability-to-mute-other-users/README.md
+++ b/projects/ability-to-mute-other-users/README.md
@@ -1,6 +1,6 @@
 ## Mute other users
 
-Users who receive unwanted messages to their [openstreetmap.org message inbox](https://www.openstreetmap.org/messages/inbox) currently have to report the message writer and wait for an administrator to take action. The OpenStreetMap website should make it possible for anyone to painlessly mute (ignore) private messages (but not comments on changesets) from another user.
+Users who receive unwanted messages to their [openstreetmap.org message inbox](https://www.openstreetmap.org/messages/inbox) currently have to report the message writer and wait for an administrator to take action. The OpenStreetMap website should make it possible for anyone to painlessly mute (ignore) private messages from another user.
 
 * Project: [openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website)
 * Related:

--- a/projects/ability-to-mute-other-users/README.md
+++ b/projects/ability-to-mute-other-users/README.md
@@ -9,7 +9,8 @@ Users who receive unwanted messages to their [openstreetmap.org message inbox](h
 
 The expected deliverable is a mergeable pull request towards https://github.com/openstreetmap/openstreetmap-website. It must at least:
 - not display messages sent from user A in user B's inbox if user B has muted user A (this includes messages sent by responding to email notifications)
-- not show any notifications to a user from muted user, including email notifications sent alongside messages
+- not show any message notifications to a user from a muted user, including email notifications sent alongside messages
+- otherwise preserve existing notification functionality for changesets, notes, diaries, etc.
 - comprise a UI such that a user can view and change which users they have muted
 - not allow admins and moderators to be muted
 - declare the business logic how past and future messages are handled in both the Inbox UI and the data model in case of muting and unmuting


### PR DESCRIPTION
Addresses the following feedback from maintainers:

- Remove references to changesets in response to this comment:
https://github.com/osmfoundation/ewg_bidding/issues/3#issuecomment-1186243093.

- Clarify scope of changes to notifications. Feedback indicates the project description has not been sufficiently clear about whether or not other notifications were to be changed. It is my understanding that our only goal is to disable notifications related to messages sent to inboxes. That seems generally in line with the consensus here: https://github.com/openstreetmap/openstreetmap-website/issues/3129