### PR TITLE
Propose a second EWG bidding project: Refactoring of OSM website notes

### DIFF
--- a/projects/openstreetmap-website-notes-refactoring/README.md
+++ b/projects/openstreetmap-website-notes-refactoring/README.md
@@ -5,6 +5,7 @@ The goal of this project is to refactor the existing notes implementation on the
 * Project: [openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website)
 * Related:
   - https://github.com/openstreetmap/openstreetmap-website/issues/3831
+  - maybe https://github.com/openstreetmap/openstreetmap-website/pull/3934
 
 The expected deliverable is a mergeable pull request towards https://github.com/openstreetmap/openstreetmap-website. It must at least:
 - Follow the idea of a refactoring by changing as little as reasonable by improving the underlying code structure
@@ -15,3 +16,16 @@ The expected deliverable is a mergeable pull request towards https://github.com/
 - Handle special cases for blocked users, hidden or removed notes and similar cases
 - Include a wireframe of all proposed UI changes
 - Conform to the [CONTRIBUTING.md doc](https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md)
+
+## Side effects
+
+A side effect of this refactoring will be that a recurring error 500 will not be possible anymore, see https://github.com/openstreetmap/openstreetmap-website/issues/2146 for more.
+
+## Possible follow up projects
+
+This refactoring will unblock follow possible follow up improvements to the website and api that are not being worked on ATM due to the outdated foundation of the notes system.
+
+For example:
+
+- Add a `source` flag to notes and comments to indicate the app or website that created the note/comment, see https://github.com/openstreetmap/openstreetmap-website/issues/3932
+- Update the notes UI, related to https://github.com/openstreetmap/openstreetmap-website/pull/3386

--- a/projects/openstreetmap-website-notes-refactoring/README.md
+++ b/projects/openstreetmap-website-notes-refactoring/README.md
@@ -8,7 +8,7 @@ The goal of this project is to refactor the existing notes implementation on the
   - maybe https://github.com/openstreetmap/openstreetmap-website/pull/3934
 
 The expected deliverable is a mergeable pull request towards https://github.com/openstreetmap/openstreetmap-website. It must at least:
-- Follow the idea of a refactoring by changing as little as reasonable by improving the underlying code structure
+- Follow the idea of a refactoring by changing as little as possible in behaviour and improving the underlying code structure
 - Handle the UI part – Map, Forms, Lists, …
 - Handle the API part – without any breaking changes to the API
 - Handle the Data migration of existing data – discuss details with the operations team

--- a/projects/openstreetmap-website-notes-refactoring/README.md
+++ b/projects/openstreetmap-website-notes-refactoring/README.md
@@ -17,15 +17,20 @@ The expected deliverable is a mergeable pull request towards https://github.com/
 - Include a wireframe of all proposed UI changes
 - Conform to the [CONTRIBUTING.md doc](https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md)
 
-## Side effects
+## Positive effects of this project
 
-A side effect of this refactoring will be that a recurring error 500 will not be possible anymore, see https://github.com/openstreetmap/openstreetmap-website/issues/2146 for more.
+**Remove bugs and improve stability:**
 
-## Possible follow up projects
+- There are situations when the Notes API returns an error 500 right now. This refactoring will solve the underlying issue. There are multiple issues and even more dupliactes on this topic, eg. https://github.com/openstreetmap/openstreetmap-website/issues/2146.
+- It will also solve edgecases like https://github.com/openstreetmap/openstreetmap-website/issues/3396
+- It will make the API more stable and easier to handle for data consumers of the API as well. StreetComplete and NotesReview (https://github.com/ENT8R/NotesReview/issues/113) are two apps that reported related problems.
+- It will make proposed workarounds obsolete which will make the code simpler and reduce maintance burdens, eg. https://github.com/openstreetmap/openstreetmap-website/pull/3617, https://github.com/openstreetmap/openstreetmap-website/issues/3744, https://github.com/openstreetmap/openstreetmap-website/pull/3607, https://github.com/openstreetmap/openstreetmap-website/pull/3608
 
-This refactoring will unblock follow possible follow up improvements to the website and api that are not being worked on ATM due to the outdated foundation of the notes system.
+**Solid foundation for follow up projects:**
 
-For example:
+There are multiple issues discussing additions to the notes system. They all require a solid foundation which this project will provide. For example:
 
 - Add a `source` flag to notes and comments to indicate the app or website that created the note/comment, see https://github.com/openstreetmap/openstreetmap-website/issues/3932
-- Update the notes UI, related to https://github.com/openstreetmap/openstreetmap-website/pull/3386
+- Extend the API for moderation use cases, see https://github.com/openstreetmap/openstreetmap-website/pull/3934
+- Update the list-of-notes-UI, see https://github.com/openstreetmap/openstreetmap-website/pull/3386
+- Add tags (or similar) to notes, see for example https://github.com/openstreetmap/openstreetmap-website/issues/3932#issuecomment-1440222022

--- a/projects/openstreetmap-website-notes-refactoring/README.md
+++ b/projects/openstreetmap-website-notes-refactoring/README.md
@@ -19,18 +19,20 @@ The expected deliverable is a mergeable pull request towards https://github.com/
 
 ## Positive effects of this project
 
-**Remove bugs and improve stability:**
+**Remove bugs, improve stability and reduce maintenance burden:**
 
-- There are situations when the Notes API returns an error 500 right now. This refactoring will solve the underlying issue. There are multiple issues and even more dupliactes on this topic, eg. https://github.com/openstreetmap/openstreetmap-website/issues/2146.
-- It will also solve edgecases like https://github.com/openstreetmap/openstreetmap-website/issues/3396
-- It will make the API more stable and easier to handle for data consumers of the API as well. StreetComplete and NotesReview (https://github.com/ENT8R/NotesReview/issues/113) are two apps that reported related problems.
-- It will make proposed workarounds obsolete which will make the code simpler and reduce maintance burdens, eg. https://github.com/openstreetmap/openstreetmap-website/pull/3617, https://github.com/openstreetmap/openstreetmap-website/issues/3744, https://github.com/openstreetmap/openstreetmap-website/pull/3607, https://github.com/openstreetmap/openstreetmap-website/pull/3608
+For example:
+
+- An issue about notes without comments https://github.com/openstreetmap/openstreetmap-website/issues/2146
+- Another issue related to notes without comments https://github.com/openstreetmap/openstreetmap-website/issues/3396
+- https://github.com/openstreetmap/openstreetmap-website/issues/3744 is waiting on the refactoring before being reviewed
+- Multiple pull request can be closed which are workarounds for the current implementation. For example https://github.com/openstreetmap/openstreetmap-website/pull/3617, https://github.com/openstreetmap/openstreetmap-website/pull/3607, https://github.com/openstreetmap/openstreetmap-website/pull/3608
 
 **Solid foundation for follow up projects:**
 
 There are multiple issues discussing additions to the notes system. They all require a solid foundation which this project will provide. For example:
 
-- Add a `source` flag to notes and comments to indicate the app or website that created the note/comment, see https://github.com/openstreetmap/openstreetmap-website/issues/3932
+- Improve notes/comments with an optional information on the app or website that created the note/comment, see https://github.com/openstreetmap/openstreetmap-website/issues/3932
 - Extend the API for moderation use cases, see https://github.com/openstreetmap/openstreetmap-website/pull/3934
 - Update the list-of-notes-UI, see https://github.com/openstreetmap/openstreetmap-website/pull/3386
 - Add tags (or similar) to notes, see for example https://github.com/openstreetmap/openstreetmap-website/issues/3932#issuecomment-1440222022

--- a/projects/openstreetmap-website-notes-refactoring/README.md
+++ b/projects/openstreetmap-website-notes-refactoring/README.md
@@ -12,7 +12,7 @@ The expected deliverable is a mergeable pull request towards https://github.com/
 - Handle the UI part – Map, Forms, Lists, …
 - Handle the API part – without any breaking changes to the API
 - Handle the Data migration of existing data – discuss details with the operations team
-- Handle freatures related to moderation and administration
+- Handle features related to moderation and administration
 - Handle special cases for blocked users, hidden or removed notes and similar cases
 - Include a wireframe of all proposed UI changes
 - Conform to the [CONTRIBUTING.md doc](https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md)

--- a/projects/openstreetmap-website-notes-refactoring/README.md
+++ b/projects/openstreetmap-website-notes-refactoring/README.md
@@ -1,0 +1,17 @@
+# OpenStreetMap-Website: Refactor Notes
+
+The goal of this project is to refactor the existing notes implementation on the OSM website.
+
+* Project: [openstreetmap-website](https://github.com/openstreetmap/openstreetmap-website)
+* Related:
+  - https://github.com/openstreetmap/openstreetmap-website/issues/3831
+
+The expected deliverable is a mergeable pull request towards https://github.com/openstreetmap/openstreetmap-website. It must at least:
+- Follow the idea of a refactoring by changing as little as reasonable by improving the underlying code structure
+- Handle the UI part – Map, Forms, Lists, …
+- Handle the API part – without any breaking changes to the API
+- Handle the Data migration of existing data – discuss details with the operations team
+- Handle freatures related to moderation and administration
+- Handle special cases for blocked users, hidden or removed notes and similar cases
+- Include a wireframe of all proposed UI changes
+- Conform to the [CONTRIBUTING.md doc](https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md)

--- a/projects/openstreetmap-website-notes-refactoring/README.md
+++ b/projects/openstreetmap-website-notes-refactoring/README.md
@@ -32,7 +32,7 @@ For example:
 
 There are multiple issues discussing additions to the notes system. They all require a solid foundation which this project will provide. For example:
 
-- Improve notes/comments with an optional information on the app or website that created the note/comment, see https://github.com/openstreetmap/openstreetmap-website/issues/3932
+- Improve notes/comments with optional details on the app or website that created the note/comment, see https://github.com/openstreetmap/openstreetmap-website/issues/3932
 - Extend the API for moderation use cases, see https://github.com/openstreetmap/openstreetmap-website/pull/3934
 - Update the list-of-notes-UI, see https://github.com/openstreetmap/openstreetmap-website/pull/3386
 - Add tags (or similar) to notes, see for example https://github.com/openstreetmap/openstreetmap-website/issues/3932#issuecomment-1440222022


### PR DESCRIPTION
In this issue https://github.com/openstreetmap/openstreetmap-website/issues/3831 Andy described the need for this refactoring and outlined a solution. This plan was confirmed by Tom.

The current system has bugs and – as Andy outlines – open PRs that try to work around its limitations are not enough to solve the underlying issue.

The goal of this bidding project is to refactor – as in "it works more or less the same but the underlying architecture and data model is better" – the notes system. 

This will give the website a better foundation to add new features to, for example a concept of tagging notes, in future contributions or maybe bidding requests.

Please find the propose project outline in the README of this PR at https://github.com/osmfoundation/ewg_bidding/pull/9/files